### PR TITLE
Allow custom qcalc binary path

### DIFF
--- a/src/tests/test_qcalc.sh
+++ b/src/tests/test_qcalc.sh
@@ -2,7 +2,14 @@
 
 echo "Starting qCalc test suite..."
 
-BIN="../../build/qcalc"
+# Optional: specify qcalc binary via command line or QCALC_BIN env var
+#   QCALC_BIN=/custom/path/qcalc ./test_qcalc.sh
+#   ./test_qcalc.sh /custom/path/qcalc
+
+BIN="${QCALC_BIN:-../../build/qcalc}"
+if [ $# -ge 1 ]; then
+    BIN="$1"
+fi
 if [ ! -x "$BIN" ]; then
     echo "ERROR: qcalc binary not found at $BIN"
     exit 1


### PR DESCRIPTION
## Summary
- allow overriding default path to `qcalc` binary in test script
- document command-line argument and environment variable usage

## Testing
- `git log -1 --stat`
