### PR TITLE
Add mpz_set_str validation

### DIFF
--- a/src/division.c
+++ b/src/division.c
@@ -183,8 +183,17 @@ void mpz_div_print(mpz_t n, mpz_t d, int debug_enabled) {
 
 void print_div_str(const char *n_str, const char *d_str, int debug_enabled) {
     mpz_t n, d;
-    mpz_init_set_str(n, n_str, 10);
-    mpz_init_set_str(d, d_str, 10);
+    if (mpz_init_set_str(n, n_str, 10) != 0) {
+        fprintf(stderr, "ERROR: Invalid integer '%s'\n", n_str);
+        mpz_clear(n);
+        return;
+    }
+    if (mpz_init_set_str(d, d_str, 10) != 0) {
+        fprintf(stderr, "ERROR: Invalid integer '%s'\n", d_str);
+        mpz_clear(n);
+        mpz_clear(d);
+        return;
+    }
     mpz_div_print(n, d, debug_enabled);
     mpz_clear(n);
     mpz_clear(d);
@@ -192,7 +201,11 @@ void print_div_str(const char *n_str, const char *d_str, int debug_enabled) {
 
 void print_field_str(const char *n_str, int debug_enabled) {
     mpz_t n, i;
-    mpz_init_set_str(n, n_str, 10);
+    if (mpz_init_set_str(n, n_str, 10) != 0) {
+        fprintf(stderr, "ERROR: Invalid integer '%s'\n", n_str);
+        mpz_clear(n);
+        return;
+    }
     mpz_init_set_ui(i, 1);
     while (mpz_cmp(i, n) != 0) {
         mpz_div_print(i, n, debug_enabled);
@@ -204,7 +217,11 @@ void print_field_str(const char *n_str, int debug_enabled) {
 
 void print_field_grid(const char *n_str, int debug_enabled) {
     mpz_t n, i;
-    mpz_init_set_str(n, n_str, 10);
+    if (mpz_init_set_str(n, n_str, 10) != 0) {
+        fprintf(stderr, "ERROR: Invalid integer '%s'\n", n_str);
+        mpz_clear(n);
+        return;
+    }
     mpz_init_set_ui(i, 1);
 
     int max_digits = 20; // Limit digits shown per cell

--- a/src/fc.c
+++ b/src/fc.c
@@ -17,7 +17,11 @@ void print_fc_str(const char *str)
 {
     mpz_t n, height;
     unsigned short int shadow;
-    mpz_init_set_str(n, str, 10);
+    if (mpz_init_set_str(n, str, 10) != 0) {
+        fprintf(stderr, "ERROR: Invalid integer '%s'\n", str);
+        mpz_clear(n);
+        return;
+    }
     mpz_init(height);
     shadow = get_fc(n, height);
     gmp_printf("n: %Zd\n", n);

--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,11 @@ void print_number_with_color(int value) {
 // Modify existing functions to use the new color printing function
 void print_field_str_color(const char *n_str, int debug_enabled) {
     mpz_t n, i;
-    mpz_init_set_str(n, n_str, 10);
+    if (mpz_init_set_str(n, n_str, 10) != 0) {
+        fprintf(stderr, "ERROR: Invalid integer '%s'\n", n_str);
+        mpz_clear(n);
+        return;
+    }
     mpz_init_set_ui(i, 1);
     while (mpz_cmp(i, n) <= 0) { // Ensure inclusive up to n
         mpz_div_print(i, n, debug_enabled);
@@ -56,7 +60,11 @@ void print_field_str_color(const char *n_str, int debug_enabled) {
 
 void print_field_str_no_color(const char *n_str, int debug_enabled) {
     mpz_t n, i;
-    mpz_init_set_str(n, n_str, 10);
+    if (mpz_init_set_str(n, n_str, 10) != 0) {
+        fprintf(stderr, "ERROR: Invalid integer '%s'\n", n_str);
+        mpz_clear(n);
+        return;
+    }
     mpz_init_set_ui(i, 1);
     while (mpz_cmp(i, n) <= 0) { // Ensure inclusive up to n
         mpz_div_print(i, n, debug_enabled);
@@ -107,7 +115,11 @@ int main(int argc, char *argv[]) {
         }
 
         mpz_t n, half_minus_one;
-        mpz_init_set_str(n, argv[2], 10);
+        if (mpz_init_set_str(n, argv[2], 10) != 0) {
+            fprintf(stderr, "ERROR: Invalid integer '%s'\n", argv[2]);
+            mpz_clear(n);
+            return 1;
+        }
 
         // Prepare strings for debug output
         char *n_str = mpz_get_str(NULL, 10, n);

--- a/src/prime.c
+++ b/src/prime.c
@@ -155,7 +155,11 @@ int prime_check(mpz_t n) {
 // Wrapper function for prime checks with optional foundational coordinates
 void print_prime_str(const char *str, int fc) {
     mpz_t n;
-    mpz_init_set_str(n, str, 10);
+    if (mpz_init_set_str(n, str, 10) != 0) {
+        fprintf(stderr, "ERROR: Invalid integer '%s'\n", str);
+        mpz_clear(n);
+        return;
+    }
     int result = prime_check(n);
     if (result) {
         printf("prime\n");

--- a/src/reciprocal.c
+++ b/src/reciprocal.c
@@ -7,7 +7,11 @@
 
 void print_reciprocal_str(const char *str) {
     mpz_t n, d;
-    mpz_init_set_str(n, str, 10);
+    if (mpz_init_set_str(n, str, 10) != 0) {
+        fprintf(stderr, "ERROR: Invalid integer '%s'\n", str);
+        mpz_clear(n);
+        return;
+    }
     mpz_init_set_ui(d, 1); // Set the denominator as 1 for reciprocal calculation
     
     // Choose whether you want debug enabled or disabled here - set to 0 or 1


### PR DESCRIPTION
## Summary
- guard parsing functions against invalid strings
- use error messages when `mpz_init_set_str` fails
- return early from operations when parsing errors occur

## Testing
- `cmake ..`
- `cmake --build .`
- `bash test_qcalc.sh`